### PR TITLE
bucket createでgsutilコマンドの使い方とsubstr()の使い方を間違えていたので修正

### DIFF
--- a/storage/bucket-creator.awk
+++ b/storage/bucket-creator.awk
@@ -122,7 +122,7 @@ function options(bucket) {
 
   for (key in bucket) {
     if (key != "name") {
-      opts = opts " -" substr(key, 0, 1) " " bucket[key]
+      opts = opts " -" substr(key, 1, 1) " " bucket[key]
     }
   }
 

--- a/storage/bucket-creator.awk
+++ b/storage/bucket-creator.awk
@@ -110,7 +110,7 @@ function bucket_name(name) {
 # [param] Associative Array bucket
 #
 function create_bucket(bucket) {
-  system("gsutil mb " bucket_name(bucket["name"]) options(bucket))
+  system("gsutil mb " options(bucket) " " bucket_name(bucket["name"]))
 }
 
 #


### PR DESCRIPTION
## ■ 修正点

 * awk の substr() は 1 origin でした
 * gsutil コマンドで bucket 名の前に option を与えるように

awk の substr() は正確には第2引数が `1` でも `0` でもマイナスでも少数でも最初の1文字目を得るためだけなら同じように機能するのだけど、0 origin であるかのように読めてしまい、これだけ読むと2文字目を 1 で取得しようとしかねず、バグを誘発するので直しておく
