### PR TITLE
[bigquery] schemaファイル名からtable名を取得するコマンドがshellによらず動作するように

### DIFF
--- a/bigquery/table-creator.awk
+++ b/bigquery/table-creator.awk
@@ -26,7 +26,8 @@ function store_schema_files(      i, filename, tablename) {
   if (ARGC > 2) {
     for (i = 0; i + 2 < ARGC; i++) {
       filename = ARGV[i+2]
-      "basename " filename " .json" | getline tablename
+      cmd = "basename " filename " .json"
+      cmd | getline tablename
       schema_files[tablename] = filename
     }
     ARGC = 2


### PR DESCRIPTION
## ■ 課題

```awk
function store_schema_files(      i, filename, tablename) {
  if (ARGC > 2) {
    for (i = 0; i + 2 < ARGC; i++) {
      filename = ARGV[i+2]
      "basename " filename " .json" | getline tablename
```

の部分で以下のようなエラーになる。

```
/bin/sh: 1: .json: not found
```

## ■ 変更

getline に与えるコマンドの文字列を動的に組み立てている場合、shell によって意図通り解釈できない場合があるので事前に組み立てた command 文字列を利用するように