### PR TITLE
[iam]compute engine default service accountをbinding設定時に省略名で書けるアカウントとして追加

### DIFF
--- a/iam-binding/README.md
+++ b/iam-binding/README.md
@@ -10,7 +10,7 @@ awk -v project_id=<..> -v project_number=<..> -f add-iam-binding.awk bindings.tx
 
  * 1 binding : described as multilines separated by blank line
  * member and roles are listed raw string
- * app engine service account and cloud build service account should be abbreviated only in domain part
+ * some service accounts are expended to a canonical address complemented by the project id
 
 ### example
 
@@ -28,3 +28,15 @@ user:foobar@example.com
 roles/storage.objectAdmin
 roles/editor
 ```
+
+### special service accounts
+
+ * cloudbuild.gserviceaccount.com
+     * Legacy CloudBuild Service Account
+     * -> \<project number\>@cloudbuild.gserviceaccount.com
+ * appspot.gserviceaccount.com
+     * App Engine Default Service Account
+	 * -> \<project number\>@appspot.gserviceaccount.com
+ * compute.gserviceaccount.com
+     * Compute Engine Default Service Account
+     * -> \<project number\>-compute@developer.gserviceaccount.com

--- a/iam-binding/add-iam-binding.awk
+++ b/iam-binding/add-iam-binding.awk
@@ -60,6 +60,8 @@ function account(name) {
     return "serviceAccount:" cloudbuild_account()
   } else if (is_appengine_account(name)) {
     return "serviceAccount:" appengine_account()
+  } else if (is_computeengine_account(name)) {
+    return "serviceAccount:" computeengine_account()
   } else {
     return name
   }
@@ -78,6 +80,21 @@ function cloudbuild_account() {
 #
 function is_cloudbuild_account(name) {
   return name == "cloudbuild.gserviceaccount.com"
+}
+
+#
+# [return] String
+#
+function computeengine_account() {
+  return project_number "-compute@developer.gserviceaccount.com"
+}
+
+#
+# [param] String name
+# [return] Boolean
+#
+function is_computeengine_account(name) {
+  return name == "compute.gserviceaccount.com"
 }
 
 #


### PR DESCRIPTION
## ■ 背景

[Cloud Build のデフォルト サービス アカウントの変更  \|  Cloud Build Documentation  \|  Google Cloud](https://cloud.google.com/build/docs/cloud-build-service-account-updates?hl=ja)

2024年の5, 6月に Cloud Build 実行時のサービスアカウントのデフォルトアカウントが変更になり、Compute Engine のdefaultサービスアカウントになったため。