### PR TITLE
function内の連想配列が再利用されてしまう問題を修正

### DIFF
--- a/bigquery/dataset-creator.awk
+++ b/bigquery/dataset-creator.awk
@@ -82,9 +82,12 @@ function read_datasets(datasets,      i, dataset) {
 # [param] Array
 # [return] Number
 #
-function split_to_assoc(record, assoc) {
+function split_to_assoc(record, assoc,    lines, capture) {
   split_to_lines(record, lines)
+
+  split("", assoc)
   size = 0
+
   for (key in lines) {
     line = lines[key]
     if (line != "") {

--- a/bigquery/table-creator.awk
+++ b/bigquery/table-creator.awk
@@ -150,9 +150,12 @@ function read_tables(tables, i, table, header, sepalator, cmd) {
 # [param] Array
 # [return] Number
 #
-function split_to_assoc(record, assoc) {
+function split_to_assoc(record, assoc,    lines, capture) {
   split_to_lines(record, lines)
+
+  split("", assoc)
   size = 0
+
   for (key in lines) {
     line = lines[key]
     if (line != "") {

--- a/cloudsql/database-creator.awk
+++ b/cloudsql/database-creator.awk
@@ -120,9 +120,12 @@ function read_databases(databases, i, database, header, cmd) {
 # [param] Array
 # [return] Number
 #
-function split_to_assoc(record, assoc) {
+function split_to_assoc(record, assoc,    lines, capture) {
   split_to_lines(record, lines)
+
+  split("", assoc)
   size = 0
+
   for (key in lines) {
     line = lines[key]
     if (line != "") {

--- a/cloudsql/instance-creator.awk
+++ b/cloudsql/instance-creator.awk
@@ -80,9 +80,12 @@ function read_instances(instances, i) {
 # [param] Array
 # [return] Number
 #
-function split_to_assoc(record, assoc) {
+function split_to_assoc(record, assoc,    lines, capture) {
   split_to_lines(record, lines)
+
+  split("", assoc)
   size = 0
+
   for (key in lines) {
     line = lines[key]
     if (line != "") {

--- a/iam-binding/add-iam-binding.awk
+++ b/iam-binding/add-iam-binding.awk
@@ -144,11 +144,14 @@ function is_service_agent(name) {
 # [param] Array
 # [return] Number
 #
-function split_to_assoc(record, assoc) {
+function split_to_assoc(record, assoc,    lines, roles) {
   split_to_lines(record, lines)
 
+  split("", assoc)
+  split("", roles)
   size = 0
   role_size = 0
+
   for (key in lines) {
     line = lines[key]
     if (line == "") continue

--- a/iam-binding/add-iam-binding.awk
+++ b/iam-binding/add-iam-binding.awk
@@ -150,15 +150,14 @@ function split_to_assoc(record, assoc,    lines, roles) {
   split("", assoc)
   split("", roles)
   size = 0
-  role_size = 0
 
   for (key in lines) {
     line = lines[key]
     if (line == "") continue
 
     if (line ~ /^roles\//) {
-      roles[role_size] = line
-      role_size++
+      roles[size] = line
+      size++
     } else {
       member = line
     }

--- a/scheduler/scheduler.awk
+++ b/scheduler/scheduler.awk
@@ -114,9 +114,12 @@ function split_to_lines(record, lines) {
 # [param] Array
 # [return] Number
 #
-function split_to_assoc(record, assoc) {
+function split_to_assoc(record, assoc,    lines, capture) {
   split(record, lines, /\n/)
+
+  split("", assoc)
   size = 0
+
   for (key in lines) {
     line = lines[key]
     if (line != "") {

--- a/storage/bucket-creator.awk
+++ b/storage/bucket-creator.awk
@@ -66,9 +66,12 @@ function read_buckets(buckets,      i, bucket) {
 # [param] Array
 # [return] Number
 #
-function split_to_assoc(record, assoc) {
+function split_to_assoc(record, assoc,    lines, capture) {
   split_to_lines(record, lines)
+
+  split("", assoc)
   size = 0
+
   for (key in lines) {
     line = lines[key]
     if (line != "") {


### PR DESCRIPTION
## ■ 問題

`split_to_assoc()` 内において assoc を中心に自動的に初期化されない連想配列が前回呼び出された時の値を保持しており、2回目の要素が1回目より少なかった場合に1回目の値が残ってしまう

## ■ 変更

必要な連想配列について明示的な初期化処理を追加

本質的な変更ではないが、以下の修正も同時に行っている

 * ローカル変数のように見えるように function の引数を使うように
 * return している変数と中で実際に使われている変数が食い違っていた ( add-iam-binding.awk ) 問題を修正
