### PR TITLE
add-iam-policy-bindingに失敗した場合に即失敗として終了するように

### DIFF
--- a/iam-binding/add-iam-binding.awk
+++ b/iam-binding/add-iam-binding.awk
@@ -30,7 +30,8 @@ BEGIN {
   split_to_assoc($0, binding)
   cmd = gcloud_cmd " " project_id options(binding)
   print cmd
-  system(cmd)
+  failure = system(cmd)
+  if (failure) exit 1
 }
 
 #


### PR DESCRIPTION
## ■ 目的

CI/CD の status が実態と合わない問題を解消する
