### PR TITLE
fix acount typo and run_service --region extraction

### DIFF
--- a/iam-binding/add-iam-binding.awk
+++ b/iam-binding/add-iam-binding.awk
@@ -50,7 +50,7 @@ function define() {
       if (resources[pos] == binding["resource"]) break
     }
 
-    if (resource == "acount") {
+    if (resource == "account") {
       cmd = cmd_write[pos] " " project_id options[i] " > /dev/null"
     } else {
       cmd = cmd_write[pos] " " options[i] " > /dev/null"

--- a/iam-binding/add-iam-binding.awk
+++ b/iam-binding/add-iam-binding.awk
@@ -63,9 +63,13 @@ function define() {
   if (resource == "account") {
     cmd = cmd_read[pos] " " project_id
   } else {
-    split(options[0], c, / +/)
+    match(binding["target"], /--region [^ ]+/)
+    region = (RSTART ? substr(binding["target"], RSTART, RLENGTH) : "")
 
-    cmd = cmd_read[pos] " " c[1]
+    match(binding["target"], /^[^ ]+/)
+    service = substr(binding["target"], RSTART, RLENGTH)
+
+    cmd = cmd_read[pos] " " service " " region
   }
   print cmd
   system(cmd)


### PR DESCRIPTION
## 変更点

Fixes two bugs in `iam-binding/add-iam-binding.awk`.

 * `"acount"` typo
 * `run_service` read command missing `--region`
