### PR TITLE
add an explanation of bigquery schema application

### DIFF
--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -2,17 +2,31 @@
 
 ### ■ Usage
 
- 1. Create Dataset
+### 1. Create Dataset
 ```
 awk -v project_id=<..> -f dataset-creator.awk datasets.txt
 ```
 
- 2. Create Table ( and update schema optionally )
+Dataset については変更・削除に対応していない（作成のみ）
+
+
+### 2. Create Table ( and update schema optionally )
 ```
-awk -v project_id=<..> -f table-creator.awk tables.txt [schema.json [schema.json] ...]
+awk -v project_id=<..> -f table-creator.awk tables.txt [<schema>.json [<schema>.json] ...]
 ```
 
-※ Dataset と Table について、変更や削除には対応していない（作成のみ）
+\<schema\>.json は tables.txt 内のテーブル名 ( `name: `  )に一致する名前のファイルが該当 table に対して適用される。
+
+schema ファイルの内容が実際の table の schema 定義に対して以下の操作に該当すれば適用される。[^1]
+
+ * カラム追加（新規作成時はすべてこれに該当）
+ * REQUIRED → NULLABLE への変更（制限の緩和）
+
+CI/CD 上でくり返し実行した際に上記操作に合致している限りは「変更」として適用できる。
+
+※ 上記に該当しない場合はエラーになるのでエラーを取り除く必要がある。
+
+[^1]: 実体は `bq update` なのでその制限に従う see https://docs.cloud.google.com/bigquery/docs/reference/bq-cli-reference#bq_update
 
 ### ■ datasets.txt format
 
@@ -21,8 +35,8 @@ awk -v project_id=<..> -f table-creator.awk tables.txt [schema.json [schema.json
  * required keys
     * `name`
     * `location`
- * optional ...  
-    `https://cloud.google.com/bigquery/docs/datasets?hl=ja#create-dataset`
+ * optional ...
+     https://cloud.google.com/bigquery/docs/datasets#create-dataset
 
 #### example
 
@@ -40,8 +54,8 @@ default_table_expiration: 3600
  * required keys
     * `name`
     * `dataset`
- * optional ...  
-    `https://cloud.google.com/bigquery/docs/tables?hl=ja#creating_an_empty_table_with_a_schema_definition`
+ * optional ...
+    https://cloud.google.com/bigquery/docs/tables#creating_an_empty_table_with_a_schema_definition
 
 #### example
 
@@ -53,4 +67,4 @@ expiration: 3600
 
 ### schema.json
 
-see [Specifying a schema  \|  BigQuery  \|  Google Cloud](https://cloud.google.com/bigquery/docs/schemas)
+see [Specifying a schema  \|  BigQuery  \|  Google Cloud](https://cloud.google.com/bigquery/docs/schemas)


### PR DESCRIPTION
## ■ Changes

Added and updated the following descriptions:

- Clarify that only Dataset is creation-only ( Table already supports schema updates )
- `<schema>.json` files whose names match a table name are automatically applied to the corresponding table
- Supported schema change types ( column addition, REQUIRED → NULLABLE relaxation )
- Behavior when run repeatedly in CI/CD
- Unsupported operations result in an error