### PR TITLE
(logging) separate IAM granting

### DIFF
--- a/logging/README.md
+++ b/logging/README.md
@@ -3,9 +3,26 @@
 ### Features
 
 * Automatically creates or updates existing sinks
-* Grants appropriate IAM permissions to sink service accounts
+* Uses a custom service account (`--custom-writer-identity`) for writing logs
 * Supports both Cloud Storage and BigQuery destinations
 * Handles partitioned tables for BigQuery destinations
+
+### Prerequisites
+
+IAM permissions for the service account must be granted **before** running this script
+using `iam-binding/add-iam-binding.awk`.
+
+**iam-binding/bindings.txt:**
+
+```
+# GCS destination
+service_account:my-logging-sa
+roles/storage.objectCreator
+
+# BigQuery destination
+service_account:my-logging-sa
+roles/bigquery.dataEditor
+```
 
 ### Usage
 
@@ -21,6 +38,21 @@ awk -v project_id=<..> -f sink-creator.awk sink.txt
  * use PROJECT_ID placeholder in destination for dynamic project substitution
  * `gcloud` options are written **without** the `--` prefix — the script prepends `--` automatically
 
+### Configuration fields
+
+* `name`: (required) Sink name
+* `destination`: (required) Log destination
+  * `bigquery.googleapis.com/projects/:PROJECT_ID/datasets/your_dataset_name`
+  * `storage.googleapis.com/your_bucket_name`
+  * `:PROJECT_ID` is replaced with the `project_id` variable at runtime
+* `service-account`: (required) Service account to use as the sink's writer identity
+  * Short form: `my-logging-sa` → resolved to `serviceAccount:my-logging-sa@PROJECT_ID.iam.gserviceaccount.com`
+  * Full form: `my-logging-sa@example.iam.gserviceaccount.com` → `serviceAccount:` prefix is added
+  * Short form is recommended — no changes needed when switching projects
+* `log-filter`: (optional) Filter expression for logs to forward
+* `use-partitioned-tables`: (optional) Set to `true` to use partitioned tables for BigQuery destinations
+* Other `gcloud logging sinks create` options can be added the same way (without `--` prefix)
+
 ### example
 
 #### Cloud Storage destination
@@ -28,6 +60,7 @@ awk -v project_id=<..> -f sink-creator.awk sink.txt
 ```
 name: audit-logs-sink
 destination: storage.googleapis.com/:PROJECT_ID-audit-logs
+service-account: my-logging-sa
 log-filter: protoPayload.serviceName="cloudaudit.googleapis.com"
 ```
 
@@ -36,6 +69,7 @@ log-filter: protoPayload.serviceName="cloudaudit.googleapis.com"
 ```
 name: app-logs-sink
 destination: bigquery.googleapis.com/projects/:PROJECT_ID/datasets/app_logs
+service-account: my-logging-sa
 log-filter: resource.type="gce_instance"
 use-partitioned-tables: true
 ```
@@ -45,10 +79,19 @@ use-partitioned-tables: true
 ```
 name: error-logs-sink
 destination: storage.googleapis.com/:PROJECT_ID-error-logs
+service-account: my-logging-sa
 log-filter: severity>=ERROR
 
 name: security-logs-sink
 destination: bigquery.googleapis.com/projects/:PROJECT_ID/datasets/security_logs
+service-account: my-logging-sa
 log-filter: protoPayload.serviceName="cloudaudit.googleapis.com" AND protoPayload.methodName!="storage.objects.get"
 use-partitioned-tables: true
 ```
+
+### Notes
+
+* `service-account` is a required field. The script exits with an error if omitted. Auto-generated writer identities are not supported — IAM permission granting is delegated to `add-iam-binding.awk`.
+* The caller must have `iam.serviceAccounts.actAs` permission on the specified service account (required for `--custom-writer-identity`).
+* **Pub/Sub destinations**: Sinks are created but write permissions (`roles/pubsub.publisher`) are not automatically granted.
+* **No delete support**: Removing a sink definition from the config file does not delete it from GCP. Delete manually with `gcloud logging sinks delete`.

--- a/logging/README.md
+++ b/logging/README.md
@@ -3,24 +3,35 @@
 ### Features
 
 * Automatically creates or updates existing sinks
-* Uses a custom service account (`--custom-writer-identity`) for writing logs
-* Supports both Cloud Storage and BigQuery destinations
+* Supports Cloud Storage and BigQuery destinations
 * Handles partitioned tables for BigQuery destinations
 
 ### Prerequisites
 
-IAM permissions for the service account must be granted **before** running this script
-using `iam-binding/add-iam-binding.awk`.
+IAM permissions must be granted **before** running this script using `iam-binding/add-iam-binding.awk`.
+
+#### Cloud Storage destination
+
+Grant permissions to the custom service account specified in `service-account:`.
 
 **iam-binding/bindings.txt:**
 
 ```
-# GCS destination
 service_account:my-logging-sa
 roles/storage.objectCreator
+```
 
-# BigQuery destination
-service_account:my-logging-sa
+#### BigQuery destination
+
+GCP automatically assigns `service-{PROJECT_NUMBER}@gcp-sa-logging.iam.gserviceaccount.com` as the writer identity.
+Grant permissions to this service agent.
+
+**iam-binding/bindings.txt:**
+
+> **Note**: `add-iam-binding.awk` grants at project level (all datasets). Dataset-level grants are not yet supported.
+
+```
+gcp-sa-logging
 roles/bigquery.dataEditor
 ```
 
@@ -45,10 +56,11 @@ awk -v project_id=<..> -f sink-creator.awk sink.txt
   * `bigquery.googleapis.com/projects/:PROJECT_ID/datasets/your_dataset_name`
   * `storage.googleapis.com/your_bucket_name`
   * `:PROJECT_ID` is replaced with the `project_id` variable at runtime
-* `service-account`: (required) Service account to use as the sink's writer identity
+* `service-account`: (optional) Service account to use as the sink's writer identity
+  * Required for Cloud Storage and other non-BigQuery destinations
+  * Omit for BigQuery destinations — GCP assigns the logging service agent automatically
   * Short form: `my-logging-sa` → resolved to `serviceAccount:my-logging-sa@PROJECT_ID.iam.gserviceaccount.com`
   * Full form: `my-logging-sa@example.iam.gserviceaccount.com` → `serviceAccount:` prefix is added
-  * Short form is recommended — no changes needed when switching projects
 * `log-filter`: (optional) Filter expression for logs to forward
 * `use-partitioned-tables`: (optional) Set to `true` to use partitioned tables for BigQuery destinations
 * Other `gcloud logging sinks create` options can be added the same way (without `--` prefix)
@@ -69,7 +81,6 @@ log-filter: protoPayload.serviceName="cloudaudit.googleapis.com"
 ```
 name: app-logs-sink
 destination: bigquery.googleapis.com/projects/:PROJECT_ID/datasets/app_logs
-service-account: my-logging-sa
 log-filter: resource.type="gce_instance"
 use-partitioned-tables: true
 ```
@@ -84,14 +95,13 @@ log-filter: severity>=ERROR
 
 name: security-logs-sink
 destination: bigquery.googleapis.com/projects/:PROJECT_ID/datasets/security_logs
-service-account: my-logging-sa
 log-filter: protoPayload.serviceName="cloudaudit.googleapis.com" AND protoPayload.methodName!="storage.objects.get"
 use-partitioned-tables: true
 ```
 
 ### Notes
 
-* `service-account` is a required field. The script exits with an error if omitted. Auto-generated writer identities are not supported — IAM permission granting is delegated to `add-iam-binding.awk`.
-* The caller must have `iam.serviceAccounts.actAs` permission on the specified service account (required for `--custom-writer-identity`).
+* `service-account` is optional. Omit it for BigQuery destinations — GCP automatically assigns the logging service agent. Required for Cloud Storage and other destinations.
+* The caller must have `iam.serviceAccounts.actAs` permission on the specified service account (required when `--custom-writer-identity` is used).
 * **Pub/Sub destinations**: Sinks are created but write permissions (`roles/pubsub.publisher`) are not automatically granted.
 * **No delete support**: Removing a sink definition from the config file does not delete it from GCP. Delete manually with `gcloud logging sinks delete`.

--- a/logging/README.md
+++ b/logging/README.md
@@ -19,6 +19,7 @@ awk -v project_id=<..> -f sink-creator.awk sink.txt
  * sink configuration : YAML-like tagged ( separator is `: ` not `:` )
  * destination supports Cloud Storage buckets and BigQuery datasets
  * use PROJECT_ID placeholder in destination for dynamic project substitution
+ * `gcloud` options are written **without** the `--` prefix — the script prepends `--` automatically
 
 ### example
 

--- a/logging/sink-creator.awk
+++ b/logging/sink-creator.awk
@@ -21,11 +21,6 @@ BEGIN {
 {
   split_to_assoc($0, sink)
 
-  if (!sink["service-account"]) {
-    print "Error: 'service-account' is required. See README.md for setup instructions."
-    exit 1
-  }
-
   state = sinks[sink["name"]]
 
   if (length(state) > 0) {
@@ -71,17 +66,22 @@ function read_sinks(sinks) {
 }
 
 function create_sink(sink) {
-  sa = resolve_service_account(sink)
-  cmd = gcloud_cmd " create " sink["name"] " " destination(sink) " --custom-writer-identity=" sa " " build_options(sink) " " use_partitioned_tables(sink)
+  cmd = gcloud_cmd " create " sink["name"] " " destination(sink) " " writer_identity_option(sink) " " build_options(sink) " " use_partitioned_tables(sink)
   print cmd
   if (system(cmd)) exit 1
 }
 
 function update_sink(sink) {
-  sa = resolve_service_account(sink)
-  cmd = gcloud_cmd " update " sink["name"] " " destination(sink) " --custom-writer-identity=" sa " " build_options(sink) " " use_partitioned_tables(sink)
+  cmd = gcloud_cmd " update " sink["name"] " " destination(sink) " " writer_identity_option(sink) " " build_options(sink) " " use_partitioned_tables(sink)
   print cmd
   if (system(cmd)) exit 1
+}
+
+function writer_identity_option(sink) {
+  if (sink["service-account"]) {
+    return "--custom-writer-identity=" resolve_service_account(sink)
+  }
+  return ""
 }
 
 function resolve_service_account(sink) {

--- a/logging/sink-creator.awk
+++ b/logging/sink-creator.awk
@@ -20,6 +20,12 @@ BEGIN {
 #
 {
   split_to_assoc($0, sink)
+
+  if (!sink["service-account"]) {
+    print "Error: 'service-account' is required. See README.md for setup instructions."
+    exit 1
+  }
+
   state = sinks[sink["name"]]
 
   if (length(state) > 0) {
@@ -65,38 +71,25 @@ function read_sinks(sinks) {
 }
 
 function create_sink(sink) {
-  print gcloud_cmd " create " sink["name"] " " destination(sink) " " build_options(sink) " " use_partitioned_tables(sink)
-  if (system(gcloud_cmd " create " sink["name"] " " destination(sink) " " build_options(sink) " " use_partitioned_tables(sink))) exit 1
-  grant_service_account_to_write(sink)
+  sa = resolve_service_account(sink)
+  cmd = gcloud_cmd " create " sink["name"] " " destination(sink) " --custom-writer-identity=" sa " " build_options(sink) " " use_partitioned_tables(sink)
+  print cmd
+  if (system(cmd)) exit 1
 }
 
 function update_sink(sink) {
-  print gcloud_cmd " update " sink["name"] " " destination(sink) " " build_options(sink) " " use_partitioned_tables(sink)
-  if (system(gcloud_cmd " update " sink["name"] " " destination(sink) " " build_options(sink) " " use_partitioned_tables(sink))) exit 1
-  grant_service_account_to_write(sink)
+  sa = resolve_service_account(sink)
+  cmd = gcloud_cmd " update " sink["name"] " " destination(sink) " --custom-writer-identity=" sa " " build_options(sink) " " use_partitioned_tables(sink)
+  print cmd
+  if (system(cmd)) exit 1
 }
 
-function grant_service_account_to_write(sink) {
-  if (role_for_destination(sink)) {
-    writer = writer_identity(sink)
-    print "Assign " role_for_destination(sink) " to " writer
-    if (system("gcloud projects add-iam-policy-binding " project_id " --member=" writer " --role=" role_for_destination(sink))) exit 1
+function resolve_service_account(sink) {
+  sa = sink["service-account"]
+  if (sa !~ /@/) {
+    sa = sa "@" project_id ".iam.gserviceaccount.com"
   }
-}
-
-function writer_identity(sink) {
-  (gcloud_cmd " describe " sink["name"] " --format='value(writerIdentity)'") | getline writer
-  return writer
-}
-
-function role_for_destination(sink) {
-  if (destination(sink) ~ /^storage.googleapis.com\/.+$/) {
-    return "roles/storage.objectCreator"
-  } else if (destination(sink) ~ /^bigquery.googleapis.com\/.+$/) {
-    return "roles/bigquery.dataEditor"
-  } else {
-    return false
-  }
+  return "serviceAccount:" sa
 }
 
 function destination(sink) {
@@ -121,7 +114,7 @@ function build_options(sink) {
   opts = ""
 
   for (key in sink) {
-    if (key != "name" && key != "destination" && key != "use-partitioned-tables") {
+    if (key != "name" && key != "destination" && key != "use-partitioned-tables" && key != "service-account") {
       if (sink[key] == true || sink[key] == false) {
         opts = opts " --" key
       } else {


### PR DESCRIPTION
## ■ Goal

Reduce the APIs and IAM permissions required to run `sink-creator.awk`.

Previously, the script automatically ran `gcloud projects add-iam-policy-binding` after creating a sink,
which required the Resource Manager API and `resourcemanager.projects.setIamPolicy`.
By delegating IAM binding to `add-iam-binding.awk`, `sink-creator.awk` now only needs permissions for sink operations.

## ■ Changes

### sink-creator.awk

- Remove `grant_service_account_to_write()`, `writer_identity()`, `role_for_destination()`
  — no more `gcloud projects add-iam-policy-binding` calls (Resource Manager API no longer required)
- Add `writer_identity_option()`: passes `--custom-writer-identity=serviceAccount:...` when `service-account:` is specified
- Add `resolve_service_account()`: expands short-form SA name to fully qualified `serviceAccount:NAME@PROJECT_ID.iam.gserviceaccount.com`
- Exclude `service-account` key from `build_options()` passthrough
- For BigQuery destinations, `service-account:` can be omitted — GCP automatically assigns the logging service agent (`service-{PROJECT_NUMBER}@gcp-sa-logging.iam.gserviceaccount.com`) as the writer identity, which `add-iam-binding.awk` already supports via `gcp-sa-logging` notation

### README

- Add Prerequisites section, split by destination type (Cloud Storage / BigQuery)
- Clarify that config keys are written without `--` prefix — the script prepends it automatically